### PR TITLE
feat: Add GetBuildLogs tool for downloading and parsing Xcode Cloud logs

### DIFF
--- a/AppStoreConnectMcp/XcodeCloudTools.cs
+++ b/AppStoreConnectMcp/XcodeCloudTools.cs
@@ -88,6 +88,15 @@ public class XcodeCloudTools
         return FormatResponse(result);
     }
 
+    [McpServerTool, Description("Download and parse build logs for a build action - returns detailed error information from Xcode build logs")]
+    public async Task<string> GetBuildLogs(
+        [Description("The action ID (from ListBuildActions)")] string actionId,
+        [Description("Number of lines to return from end of each log file (default: 500)")] int tailLines = 500,
+        CancellationToken cancellationToken = default)
+    {
+        return await _client.GetBuildLogsAsync(actionId, tailLines, cancellationToken);
+    }
+
     private static string FormatResponse(JsonDocument doc)
     {
         return JsonSerializer.Serialize(doc, new JsonSerializerOptions { WriteIndented = true });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Two options for testing changes:
 | ListArtifacts | List build artifacts | Done |
 | GetTestResults | Get test results | Done |
 | ListIssues | List build errors/warnings | Done |
+| GetBuildLogs | Download & parse build logs | Done |
 
 ## Potential Enhancements
 
@@ -69,7 +70,6 @@ Two options for testing changes:
 - [ ] **CancelBuild** - Cancel a running build
 
 ### Medium Priority
-- [ ] **DownloadArtifact** - Download build logs/archives
 - [ ] **ListApps** - List all apps (not just Xcode Cloud enabled)
 - [ ] **GetApp** - Get app details (bundle ID, name, etc.)
 - [ ] **ListBetaTesters** - List TestFlight testers


### PR DESCRIPTION
## Summary
- Add `GetBuildLogs` MCP tool that downloads and parses Xcode Cloud build logs
- Enables Claude to diagnose build failures by reading actual xcodebuild output

## Changes
- `AppStoreConnectClient.cs`: Add `GetArtifactAsync`, `DownloadFileAsync`, `GetBuildLogsAsync`, and log parsing logic
- `XcodeCloudTools.cs`: Add `GetBuildLogs` tool definition
- `CLAUDE.md`: Update tool documentation

## How It Works
1. Lists artifacts for the given action ID
2. Finds the `LOG_BUNDLE` artifact
3. Gets the download URL from the artifact details
4. Downloads the zip file
5. Extracts and parses relevant log files (`.log`, `.txt`, xcodebuild output)
6. Prioritizes files containing errors
7. Returns the last N lines plus any earlier error lines

## Usage
```
GetBuildLogs(actionId: "df2588b3-8589-4df1-b2b8-f8ee34d5ad57", tailLines: 500)
```

## Test Plan
- [x] Build succeeds (`dotnet build`)
- [ ] Test with a failed build to verify log extraction (requires Claude Code restart)

Closes Stig-Johnny/cutie#250

🤖 Generated with [Claude Code](https://claude.com/claude-code)