### PR TITLE
feat: Add bundle ID and Xcode Cloud setup tools

### DIFF
--- a/AppStoreConnectMcp/XcodeCloudTools.cs
+++ b/AppStoreConnectMcp/XcodeCloudTools.cs
@@ -155,6 +155,140 @@ Or use App Store Connect web:
 3. Find the build and cancel it";
     }
 
+    [McpServerTool, Description("Check if an app is set up for Xcode Cloud and get setup instructions if not")]
+    public async Task<string> CheckXcodeCloudSetup(
+        [Description("The bundle ID to check (e.g., 'com.example.app')")] string bundleId,
+        CancellationToken cancellationToken = default)
+    {
+        var result = new System.Text.StringBuilder();
+        result.AppendLine($"## Xcode Cloud Setup Check: {bundleId}");
+        result.AppendLine();
+
+        // Step 1: Check if bundle ID exists
+        try
+        {
+            var bundleIdsResult = await _client.GetAsync($"/bundleIds?filter[identifier]={bundleId}", cancellationToken);
+            var bundleIds = bundleIdsResult.RootElement.GetProperty("data");
+
+            if (bundleIds.GetArrayLength() == 0)
+            {
+                result.AppendLine("❌ **Bundle ID not registered**");
+                result.AppendLine();
+                result.AppendLine("Use the `RegisterBundleId` tool to register it:");
+                result.AppendLine($"- identifier: `{bundleId}`");
+                result.AppendLine("- name: `Your App Name`");
+                result.AppendLine("- platform: `IOS`");
+                return result.ToString();
+            }
+            result.AppendLine("✅ Bundle ID is registered");
+        }
+        catch
+        {
+            result.AppendLine("⚠️ Could not check bundle ID status");
+        }
+
+        // Step 2: Check if app exists in App Store Connect
+        try
+        {
+            var appsResult = await _client.GetAsync($"/apps?filter[bundleId]={bundleId}", cancellationToken);
+            var apps = appsResult.RootElement.GetProperty("data");
+
+            if (apps.GetArrayLength() == 0)
+            {
+                result.AppendLine("❌ **App not registered in App Store Connect**");
+                result.AppendLine();
+                result.AppendLine("The App Store Connect API does **not** support creating apps programmatically.");
+                result.AppendLine("You must create the app manually:");
+                result.AppendLine();
+                result.AppendLine("1. Go to https://appstoreconnect.apple.com");
+                result.AppendLine("2. Click '+ New App' or 'My Apps' → '+'");
+                result.AppendLine("3. Fill in:");
+                result.AppendLine($"   - Bundle ID: Select `{bundleId}`");
+                result.AppendLine("   - Name: Your app name");
+                result.AppendLine("   - Primary Language: English (US)");
+                result.AppendLine("   - SKU: Unique identifier (e.g., your-app-001)");
+                result.AppendLine("4. Click 'Create'");
+                return result.ToString();
+            }
+
+            var appId = apps[0].GetProperty("id").GetString();
+            var appName = apps[0].GetProperty("attributes").GetProperty("name").GetString();
+            result.AppendLine($"✅ App exists: {appName} (ID: {appId})");
+        }
+        catch
+        {
+            result.AppendLine("⚠️ Could not check app status");
+        }
+
+        // Step 3: Check if app has Xcode Cloud products
+        try
+        {
+            var productsResult = await _client.ListCiProductsAsync(cancellationToken);
+            var products = productsResult.RootElement.GetProperty("data");
+
+            string? matchingProductId = null;
+            foreach (var product in products.EnumerateArray())
+            {
+                var productBundleId = product.GetProperty("attributes").GetProperty("bundleId").GetString();
+                if (productBundleId == bundleId)
+                {
+                    matchingProductId = product.GetProperty("id").GetString();
+                    var productName = product.GetProperty("attributes").GetProperty("name").GetString();
+                    result.AppendLine($"✅ Xcode Cloud product exists: {productName} (ID: {matchingProductId})");
+                    break;
+                }
+            }
+
+            if (matchingProductId == null)
+            {
+                result.AppendLine("❌ **Xcode Cloud not configured**");
+                result.AppendLine();
+                result.AppendLine("Xcode Cloud must be set up from Xcode:");
+                result.AppendLine();
+                result.AppendLine("1. Open your project in Xcode");
+                result.AppendLine("2. Select Product → Xcode Cloud → Create Workflow");
+                result.AppendLine("3. Connect your GitHub/GitLab repository");
+                result.AppendLine("4. Configure your first workflow");
+                result.AppendLine();
+                result.AppendLine("After setup, use `ListProducts` to verify, then `ListWorkflows` to see workflows.");
+                return result.ToString();
+            }
+
+            // Step 4: List workflows if product exists
+            var workflowsResult = await _client.ListWorkflowsAsync(matchingProductId!, cancellationToken);
+            var workflows = workflowsResult.RootElement.GetProperty("data");
+
+            if (workflows.GetArrayLength() == 0)
+            {
+                result.AppendLine("⚠️ No workflows configured");
+                result.AppendLine();
+                result.AppendLine("Create a workflow in Xcode: Product → Xcode Cloud → Manage Workflows");
+            }
+            else
+            {
+                result.AppendLine($"✅ {workflows.GetArrayLength()} workflow(s) configured:");
+                foreach (var workflow in workflows.EnumerateArray())
+                {
+                    var workflowName = workflow.GetProperty("attributes").GetProperty("name").GetString();
+                    var workflowId = workflow.GetProperty("id").GetString();
+                    result.AppendLine($"   - {workflowName} (ID: {workflowId})");
+                }
+                result.AppendLine();
+                result.AppendLine("Use `StartBuild` with a workflow ID to trigger a build.");
+            }
+        }
+        catch
+        {
+            result.AppendLine("⚠️ Could not check Xcode Cloud products");
+        }
+
+        result.AppendLine();
+        result.AppendLine("---");
+        result.AppendLine("**Setup Complete!** Your app is ready for Xcode Cloud.");
+
+        return result.ToString();
+    }
+
     private static string FormatResponse(JsonDocument doc)
     {
         return JsonSerializer.Serialize(doc, new JsonSerializerOptions { WriteIndented = true });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,14 @@ Two options for testing changes:
 | GetWorkflow | Get workflow details (branch filters, triggers) | Done |
 | StartBuild | Trigger a new build for a workflow | Done |
 | CancelBuild | Returns manual instructions (API doesn't support cancel) | Done |
+| CheckXcodeCloudSetup | Check if app is ready for Xcode Cloud with setup guidance | Done |
+
+### Bundle ID Tools
+
+| Tool | Description | Status |
+|------|-------------|--------|
+| ListBundleIds | List all registered bundle IDs | Done |
+| RegisterBundleId | Register a new bundle ID in Apple Developer | Done |
 
 ### App Store Tools
 


### PR DESCRIPTION
## Summary

Add new tools to help with app setup automation:

- **ListBundleIds**: List all registered bundle IDs in Apple Developer account
- **RegisterBundleId**: Register a new bundle ID (required before creating an app in App Store Connect)
- **CheckXcodeCloudSetup**: Comprehensive setup checker that verifies:
  - Bundle ID registration
  - App existence in App Store Connect
  - Xcode Cloud product configuration
  - Workflow availability

## Important Note

The App Store Connect API does **not** support creating apps programmatically. The `CheckXcodeCloudSetup` tool provides clear instructions for manual steps when needed.

## Test Plan

- [ ] `dotnet build` succeeds
- [ ] Test `ListBundleIds` returns existing bundle IDs
- [ ] Test `RegisterBundleId` can create a new bundle ID
- [ ] Test `CheckXcodeCloudSetup` provides accurate status and guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)